### PR TITLE
Fix Christmas date check

### DIFF
--- a/swiftchan/Extensions/CoreExtensions.swift
+++ b/swiftchan/Extensions/CoreExtensions.swift
@@ -424,8 +424,10 @@ extension Date {
 
         if let christmasEveDate = Calendar.current.date(from: christmasEve),
            let christmasDate = Calendar.current.date(from: christmas),
-           let christmasAfter=Calendar.current.date(from: christmas) {
-            return Calendar.current.isDateInToday(christmasEveDate) || Calendar.current.isDateInToday(christmasDate) || Calendar.current.isDateInToday(christmasAfter)
+           let christmasAfterDate = Calendar.current.date(from: christmasAfter) {
+            return Calendar.current.isDateInToday(christmasEveDate) ||
+                Calendar.current.isDateInToday(christmasDate) ||
+                Calendar.current.isDateInToday(christmasAfterDate)
         }
         return false
     }


### PR DESCRIPTION
## Summary
- correct `isChristmas` to check the day after Christmas with the right date components

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6843168ccaa883259a05bfed6dd6eff8