### PR TITLE
Improve VLC webm stability

### DIFF
--- a/swiftchan/Views/Media/VLC/VLCContainerView.swift
+++ b/swiftchan/Views/Media/VLC/VLCContainerView.swift
@@ -58,26 +58,15 @@ struct VLCContainerView: View {
                 }
             }
         }
-        .onChange(of: vlcVideoViewModel.video.downloadProgress.isFinished) {
-            if vlcVideoViewModel.video.downloadProgress.isFinished && isSelected {
-                print("PLaying video 1: \(vlcVideoViewModel.video.url)")
-                vlcVideoViewModel.play()
-            }
-        }
         .onChange(of: isSelected) {
             if isSelected && vlcVideoViewModel.video.downloadProgress.isFinished {
-                print("PLaying video 2: \(vlcVideoViewModel.video.url)")
                 vlcVideoViewModel.play()
-            } else {
+            } else if !isSelected {
                 vlcVideoViewModel.pause()
             }
         }
         .onAppear {
             UIApplication.shared.isIdleTimerDisabled = true
-            if isSelected {
-                print("PLaying video 3: \(vlcVideoViewModel.video.url)")
-                vlcVideoViewModel.play()
-            }
         }
         .onDisappear {
             vlcVideoViewModel.pause()
@@ -85,6 +74,9 @@ struct VLCContainerView: View {
         }
         .task {
             try? await vlcVideoViewModel.download()
+            if isSelected {
+                vlcVideoViewModel.play()
+            }
         }
     }
 }

--- a/swiftchan/Views/Media/VLC/VLCMediaListPlayerUIView.swift
+++ b/swiftchan/Views/Media/VLC/VLCMediaListPlayerUIView.swift
@@ -27,6 +27,7 @@ class VLCMediaListPlayerUIView: UIView, VLCMediaPlayerDelegate {
 
     /// Initialize the media with options and setup the media player.
     func initialize(url: URL) {
+        resetPlayer()
         media = VLCMedia(url: url)
         if let media = media {
             media.addOption("-vv")
@@ -40,6 +41,15 @@ class VLCMediaListPlayerUIView: UIView, VLCMediaPlayerDelegate {
             mediaListPlayer.mediaPlayer.audio?.isMuted = true
             #endif
         }
+    }
+
+    /// Safely stop playback and release current media.
+    private func resetPlayer() {
+        mediaListPlayer.stop()
+        mediaListPlayer.mediaPlayer.delegate = nil
+        mediaListPlayer.mediaPlayer.drawable = nil
+        mediaListPlayer.mediaPlayer.media = nil
+        mediaListPlayer.rootMedia = nil
     }
 
 
@@ -113,10 +123,7 @@ class VLCMediaListPlayerUIView: UIView, VLCMediaPlayerDelegate {
     /// Clean up the media player to prevent callbacks on deallocated objects.
     public static func dismantleUIView(_ uiView: VLCMediaListPlayerUIView, coordinator: VLCVideoView.Coordinator) {
         DispatchQueue.main.async {
-            uiView.mediaListPlayer.mediaPlayer.delegate = nil
-            uiView.mediaListPlayer.mediaPlayer.drawable = nil
-            uiView.mediaListPlayer.stop()
-            uiView.mediaListPlayer.rootMedia = nil
+            uiView.resetPlayer()
         }
     }
 
@@ -126,11 +133,7 @@ class VLCMediaListPlayerUIView: UIView, VLCMediaPlayerDelegate {
 
     deinit {
         debugPrint("🧹 VLCMediaListPlayerUIView deinit")
-        mediaListPlayer.stop()
-        mediaListPlayer.mediaPlayer.delegate = nil
-        mediaListPlayer.mediaPlayer.drawable = nil
-        mediaListPlayer.rootMedia = nil
-        mediaListPlayer.mediaPlayer.media = nil
+        resetPlayer()
     }
     
     func setDelegate(_ delegate: VLCMediaPlayerDelegate) {


### PR DESCRIPTION
## Summary
- reset player before reinitializing VLCMediaListPlayerUIView
- centralize cleanup logic and use in dismantle/deinit
- start playback only after the video download completes

## Testing
- `swift test -list-tests` *(fails: Missing value for '-s <specifier>')*
- `xcodebuild -list -workspace swiftchan.xcworkspace -scheme swiftchan -destination 'platform=iOS Simulator,name=iPhone 14' test` *(fails: command not found)*
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684316d0df8883259ee2e2097816bbd1