### PR TITLE
Add cross-thread link handling

### DIFF
--- a/swiftchan/Extensions/CoreExtensions.swift
+++ b/swiftchan/Extensions/CoreExtensions.swift
@@ -243,6 +243,7 @@ extension URL {
     enum DetailType: String {
         case reply = "/reply"
         case board = "/board"
+        case thread = "/thread"
         case none
     }
 
@@ -256,6 +257,10 @@ extension URL {
 
     static func board(name: String) -> Self {
         Self(string: "swiftchan:\(URL.DetailType.board.rawValue)?name=\(name)")!
+    }
+
+    static func thread(board: String, id: String) -> Self {
+        Self(string: "swiftchan:\(URL.DetailType.thread.rawValue)?board=\(board)&id=\(id)")!
     }
 
 }

--- a/swiftchan/Models/ThreadDestination.swift
+++ b/swiftchan/Models/ThreadDestination.swift
@@ -1,0 +1,13 @@
+//
+//  ThreadDestination.swift
+//  swiftchan
+//
+//  Created by Codex on 2024-04-15.
+//
+
+import Foundation
+
+struct ThreadDestination: Hashable {
+    let board: String
+    let id: Int
+}

--- a/swiftchan/Services/CommentParser.swift
+++ b/swiftchan/Services/CommentParser.swift
@@ -57,23 +57,39 @@ class CommentParser {
                 else {
                     part.foregroundColor = Colors.Text.crossThreadReply
                     part.font = font
-                    
-                    // text: >>>/pol/
-                    // href: //boards.4chan.org/pol/
+
+                    // text: >>>/pol/ or >>>/g/123456
                     if text.starts(with: ">>>") {
-                        part.link = URL.board(name: text.replacingOccurrences(of: ">>>", with: "").replacingOccurrences(of: "/", with: ""))
+                        let trimmed = text.replacingOccurrences(of: ">>>/", with: "")
+                        let components = trimmed.split(separator: "/")
+                        if components.count >= 2 {
+                            let board = String(components[0])
+                            let id = String(components[1])
+                            part.link = URL.thread(board: board, id: id)
+                        } else {
+                            part.link = URL.board(name: trimmed.replacingOccurrences(of: "/", with: ""))
+                        }
                     }
-                    // text: >>794515
-                    // href: /3/thread/794515#p794515
-                    // TODO: get cross thread replies
+                    // text: >>794515 with cross thread href
                     else if text.starts(with: ">>") {
-                        part.link = URL(string: "swiftchan:Post?id=\(text.replacingOccurrences(of: ">>", with: ""))")
+                        if href.contains("/thread/") {
+                            let components = href.split(separator: "/")
+                            if components.count >= 3 {
+                                let board = String(components[1])
+                                let idComponent = components.last ?? ""
+                                let id = idComponent.split(separator: "#").first.map(String.init) ?? ""
+                                part.link = URL.thread(board: board, id: id)
+                            } else {
+                                part.link = URL(string: href)
+                            }
+                        } else {
+                            part.link = URL(string: "swiftchan:Post?id=\(text.replacingOccurrences(of: ">>", with: ""))")
+                        }
                     }
                     // link without protocol
                     else {
                         part.link = URL(string: href)
                     }
-                    //part.link = URL(string: "swiftchan://\(part)")!
                 }
 
             case .plain(text: let text):

--- a/swiftchan/Services/DeepLinker.swift
+++ b/swiftchan/Services/DeepLinker.swift
@@ -10,7 +10,7 @@ import Foundation
 class Deeplinker {
     enum Deeplink: Equatable {
         case board(name: String)
-        case thread(id: String)
+        case thread(board: String, id: String)
         case post(id: String)
         case gallery(id: String)
         case none
@@ -22,6 +22,11 @@ class Deeplinker {
         case .board:
             let name = String(url.query?.split(separator: "=").last ?? "")
             return .board(name: name)
+        case .thread:
+            let queryItems = URLComponents(url: url, resolvingAgainstBaseURL: false)?.queryItems
+            let board = queryItems?.first(where: { $0.name == "board" })?.value ?? ""
+            let id = queryItems?.first(where: { $0.name == "id" })?.value ?? ""
+            return .thread(board: board, id: id)
         case .reply:
             let id = String(url.query?.split(separator: "=").last ?? "")
             return .post(id: id)

--- a/swiftchan/Views/Boards/BoardsView.swift
+++ b/swiftchan/Views/Boards/BoardsView.swift
@@ -52,10 +52,18 @@ struct BoardsView: View {
                 .navigationDestination(for: String.self) { value in
                     CatalogView(boardName: value)
                 }
+                .navigationDestination(for: ThreadDestination.self) { dest in
+                    ThreadView(boardName: dest.board, postNumber: dest.id)
+                }
             }
             .onOpenURL { url in
-                if case .board(let name) = Deeplinker.getType(url: url) {
+                switch Deeplinker.getType(url: url) {
+                case .board(let name):
                     presentedNavigation.append(name)
+                case .thread(let board, let id):
+                    presentedNavigation.append(ThreadDestination(board: board, id: Int(id) ?? 0))
+                default:
+                    break
                 }
             }
         case .error:


### PR DESCRIPTION
## Summary
- support a new `thread` URL scheme
- parse cross-thread links in comments
- update deeplinker and boards view to route these links
- enable navigation from thread view to other threads

## Testing
- `swift --version`
- `swiftc --version`
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6844408417388325af67cc70d0834976