### PR TITLE
Fix crash from libVLC event detach

### DIFF
--- a/swiftchan/Views/Media/VLC/VLCMediaListPlayerUIView.swift
+++ b/swiftchan/Views/Media/VLC/VLCMediaListPlayerUIView.swift
@@ -49,10 +49,12 @@ class VLCMediaListPlayerUIView: UIView, VLCMediaPlayerDelegate {
     /// Safely stop playback and release current media.
     private func resetPlayer() {
         let cleanup = {
-            self.mediaListPlayer.stop()
-            self.mediaListPlayer.mediaPlayer.stop()
+            // Detach the delegate and drawable first to avoid callbacks on
+            // a deallocated object. Then stop playback and clear the media.
             self.mediaListPlayer.mediaPlayer.delegate = nil
             self.mediaListPlayer.mediaPlayer.drawable = nil
+            self.mediaListPlayer.mediaPlayer.stop()
+            self.mediaListPlayer.stop()
             self.mediaListPlayer.mediaPlayer.media = nil
             self.mediaListPlayer.rootMedia = nil
             self.currentMediaURL = nil


### PR DESCRIPTION
## Summary
- detach VLC delegate & drawable before stopping the player

## Testing
- `bundle exec fastlane tests` *(fails: bundler not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684997b872688325a204b03c9e0af4b9