### PR TITLE
Fix video pause when paging

### DIFF
--- a/swiftchan/Views/Boards/Catalog/Thread/PostView.swift
+++ b/swiftchan/Views/Boards/Catalog/Thread/PostView.swift
@@ -54,7 +54,9 @@ struct PostView: View {
                             .onTapGesture {
                                 withAnimation(.easeInOut(duration: 0.3)) {
                                     let mediaIndex = viewModel.postMediaMapping[index] ?? 0
-                                    viewModel.media[mediaIndex].isSelected = true
+                                    var item = viewModel.media[mediaIndex]
+                                    item.isSelected = true
+                                    viewModel.media[mediaIndex] = item
                                     presentationState.galleryIndex = mediaIndex
                                     presentationState.presentingGallery = true
                                 }

--- a/swiftchan/Views/Media/Gallery/GalleryView.swift
+++ b/swiftchan/Views/Media/Gallery/GalleryView.swift
@@ -73,12 +73,18 @@ struct GalleryView: View {
                 onPageDragChanged?(.zero)
                 state.galleryIndex = index
                 if index - 1 >= 0 {
-                    viewModel.media[index - 1].isSelected = false
+                    var item = viewModel.media[index - 1]
+                    item.isSelected = false
+                    viewModel.media[index - 1] = item
                 }
                 if index + 1 <= viewModel.media.count - 1 {
-                    viewModel.media[index + 1].isSelected = false
+                    var item = viewModel.media[index + 1]
+                    item.isSelected = false
+                    viewModel.media[index + 1] = item
                 }
-                viewModel.media[index].isSelected = true
+                var currentItem = viewModel.media[index]
+                currentItem.isSelected = true
+                viewModel.media[index] = currentItem
             }
             .allowsDragging(canPage)
             .pagingPriority(.simultaneous)


### PR DESCRIPTION
## Summary
- ensure `isSelected` changes trigger view updates by reassigning array items
- update gallery and post views so videos pause when swiping away

## Testing
- `apt-get update`
- `apt-get install -y swiftlint` *(fails: Unable to locate package)*
- `swift test` *(fails: Could not find Package.swift)*


------
https://chatgpt.com/codex/tasks/task_e_684b559ebd5083258be48f99a5d0bff0