### PR TITLE
Fix VLC video download progress UI

### DIFF
--- a/swiftchan/Views/Media/VLC/VLCContainerView.swift
+++ b/swiftchan/Views/Media/VLC/VLCContainerView.swift
@@ -37,12 +37,11 @@ struct VLCContainerView: View {
 
             if !vlcVideoViewModel.video.downloadProgress.isFinished {
                 VStack {
-                    ProgressView(value: vlcVideoViewModel.video.downloadProgress.fractionCompleted)
-                        .progressViewStyle(.linear)
-                        .padding()
-
+                    Text("Downloading")
+                        .foregroundColor(.white)
                     Text("\(Int(vlcVideoViewModel.video.downloadProgress.fractionCompleted * 100))%")
                         .foregroundColor(.white)
+                        .font(.title)
                 }
             }
             if vlcVideoViewModel.video.downloadProgress.isFinished && vlcVideoViewModel.video.mediaState == .buffering {


### PR DESCRIPTION
## Summary
- update `VLCVideoViewModel` progress tracking with Combine
- show simple download percentage overlay instead of a progress bar

## Testing
- `swift test -v` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_684b5602d5b48325a05a82d653c4e083