### PR TITLE
Handle auto refresh errors with toast

### DIFF
--- a/swiftchan/Views/Boards/Catalog/Thread/ThreadView.swift
+++ b/swiftchan/Views/Boards/Catalog/Thread/ThreadView.swift
@@ -29,6 +29,8 @@ struct ThreadView: View {
     @State private var replyId: Int = 0
     @State private var showThread: Bool = false
     @State private var threadDestination = ThreadDestination(board: "", id: 0)
+    @State private var showAutoRefreshToast: Bool = false
+    @State private var autoRefreshToastMessage: String = ""
 
     var scene: SKScene {
         let scene = SnowScene()
@@ -53,7 +55,8 @@ struct ThreadView: View {
     var body: some View {
         @Bindable var appState = appState
 
-        switch viewModel.state {
+        Group {
+            switch viewModel.state {
         case .initial:
             Text(viewModel.progressText)
                 .task {
@@ -141,7 +144,7 @@ struct ThreadView: View {
                 if threadAutorefresher.incrementRefreshTimer() {
                     print("Thread auto refresh timer met, updating thread.")
                     Task {
-                        await fetchAndPrefetchMedia()
+                        await fetchAndPrefetchMedia(auto: true)
                     }
                 }
 
@@ -208,7 +211,11 @@ struct ThreadView: View {
         case .error:
             Text("Thread contains no posts.")
                 .foregroundColor(.red)
-
+        }
+        }
+        .toast(isPresented: $showAutoRefreshToast, dismissAfter: 0.5) {
+            ToastView(autoRefreshToastMessage, content: {}, background: { Color.clear })
+                .toastViewStyle(ErrorToastViewStyle())
         }
     }
 
@@ -232,9 +239,15 @@ struct ThreadView: View {
         }
     }
 
-    private func fetchAndPrefetchMedia() async {
+    private func fetchAndPrefetchMedia(auto: Bool = false) async {
+        let hadPosts = !viewModel.posts.isEmpty
         await viewModel.getPosts()
-        viewModel.prefetch()
+        if viewModel.state == .loaded {
+            viewModel.prefetch()
+        } else if auto {
+            autoRefreshToastMessage = hadPosts ? "Could not auto refresh" : "Thread not found"
+            showAutoRefreshToast = true
+        }
     }
 
     private func scrollToPost(reader: ScrollViewProxy) {


### PR DESCRIPTION
## Summary
- notify the user when auto refresh fails
- show a toast that the thread can't be refreshed or is gone

## Testing
- `swift test` *(fails: Could not find Package.swift)*
- `bundle exec fastlane tests` *(fails: command not found: fastlane)*

------
https://chatgpt.com/codex/tasks/task_e_687258d9771483259ab57dec6956a1dc