### PR TITLE
WIP: Gallery expanding animation (#14)

### DIFF
--- a/swiftchan.xcodeproj/project.pbxproj
+++ b/swiftchan.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		549DB3585CF7DBE5800AD093 /* GalleryNamespaceKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = 951BEC5E7078A59F1215DD0F /* GalleryNamespaceKey.swift */; };
 		09B1DFCA9F650DAC27B6DB21 /* RecurringFavorite.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3078F0A90C5AA80AB504C21B /* RecurringFavorite.swift */; };
 		1A5F76AD0CB8E1E22917C335 /* RecurringFavoriteViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83D12254DE163971EE1E9188 /* RecurringFavoriteViewModel.swift */; };
 		2C999DFDE990B515FFB0B779 /* AddRecurringFavoriteSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9044AE15507088A1373984CA /* AddRecurringFavoriteSheet.swift */; };
@@ -130,6 +131,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		951BEC5E7078A59F1215DD0F /* GalleryNamespaceKey.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GalleryNamespaceKey.swift; sourceTree = "<group>"; };
 		3078F0A90C5AA80AB504C21B /* RecurringFavorite.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = RecurringFavorite.swift; sourceTree = "<group>"; };
 		5DAF769CBA7D852E789BB9FE /* FavoritesView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = FavoritesView.swift; sourceTree = "<group>"; };
 		83D12254DE163971EE1E9188 /* RecurringFavoriteViewModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = RecurringFavoriteViewModel.swift; sourceTree = "<group>"; };
@@ -477,6 +479,7 @@
 			children = (
 				95C73105256CA1F700F18257 /* UserSettings.swift */,
 				9524E19E256F272200D08075 /* AppState.swift */,
+				951BEC5E7078A59F1215DD0F /* GalleryNamespaceKey.swift */,
 			);
 			path = Environment;
 			sourceTree = "<group>";
@@ -740,6 +743,7 @@
 				95DBF2082712550C00356D8F /* AnimatedImage.swift in Sources */,
 				958D0998254D346A00AD4849 /* CatalogView.swift in Sources */,
 				95C73106256CA1F700F18257 /* UserSettings.swift in Sources */,
+				549DB3585CF7DBE5800AD093 /* GalleryNamespaceKey.swift in Sources */,
 				95C01FE927386D2B000D64B1 /* SettingsView.swift in Sources */,
 				951053712566018D002E4051 /* Board.swift in Sources */,
 				95105379256608E5002E4051 /* CommentParser.swift in Sources */,

--- a/swiftchan.xcodeproj/xcshareddata/xcschemes/swiftchan.xcscheme
+++ b/swiftchan.xcodeproj/xcshareddata/xcschemes/swiftchan.xcscheme
@@ -38,6 +38,16 @@
                ReferencedContainer = "container:swiftchan.xcodeproj">
             </BuildableReference>
          </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "951817A8254CFB620032616E"
+               BuildableName = "swiftchanUITests.xctest"
+               BlueprintName = "swiftchanUITests"
+               ReferencedContainer = "container:swiftchan.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
    </TestAction>
    <LaunchAction

--- a/swiftchan/Environment/GalleryNamespaceKey.swift
+++ b/swiftchan/Environment/GalleryNamespaceKey.swift
@@ -1,0 +1,17 @@
+//
+//  GalleryNamespaceKey.swift
+//  swiftchan
+//
+
+import SwiftUI
+
+struct GalleryNamespaceKey: EnvironmentKey {
+    static let defaultValue: Namespace.ID? = nil
+}
+
+extension EnvironmentValues {
+    var galleryNamespace: Namespace.ID? {
+        get { self[GalleryNamespaceKey.self] }
+        set { self[GalleryNamespaceKey.self] = newValue }
+    }
+}

--- a/swiftchan/Views/Boards/Catalog/OPView.swift
+++ b/swiftchan/Views/Boards/Catalog/OPView.swift
@@ -11,7 +11,6 @@ import FourChan
 struct OPView: View {
     @AppStorage("showOPPreview") var showOPPreview: Bool = false
     @Environment(AppState.self) var appState
-    @Namespace var fullscreenNspace
 
     let index: Int
     let boardName: String

--- a/swiftchan/Views/Boards/Catalog/Thread/PostView.swift
+++ b/swiftchan/Views/Boards/Catalog/Thread/PostView.swift
@@ -12,6 +12,7 @@ struct PostView: View {
     @Environment(ThreadViewModel.self) private var viewModel
     @Environment(AppState.self) private var appState
     @Environment(PresentationState.self) private var presentationState: PresentationState
+    @Environment(\.galleryNamespace) private var galleryNamespace
 
     let index: Int
 
@@ -50,8 +51,14 @@ struct PostView: View {
                             .accessibilityIdentifier(AccessibilityIdentifiers.thumbnailMediaImage(index))
                             .frame(width: UIScreen.halfWidth)
                             .scaledToFill() // VStack
+                            .matchedGeometryEffect(
+                                id: "gallery-\(mediaIndex)",
+                                in: galleryNamespace ?? Namespace().wrappedValue,
+                                isSource: !(presentationState.presentingGallery && presentationState.galleryIndex == mediaIndex)
+                            )
+                            .opacity(presentationState.presentingGallery && presentationState.galleryIndex == mediaIndex ? 0 : 1)
                             .onTapGesture {
-                                withAnimation(.easeInOut(duration: 0.3)) {
+                                withAnimation(.spring(response: 0.35, dampingFraction: 0.85)) {
                                     viewModel.media[mediaIndex].isSelected = true
                                     presentationState.galleryIndex = mediaIndex
                                     presentationState.presentingGallery = true

--- a/swiftchan/Views/Boards/Catalog/Thread/ThreadView.swift
+++ b/swiftchan/Views/Boards/Catalog/Thread/ThreadView.swift
@@ -20,6 +20,8 @@ struct ThreadView: View {
     @Environment(\.modelContext) private var modelContext
     // @Query private var allFavorites: [FavoriteThread]
 
+    @Namespace private var galleryNamespace
+
     @State private var presentationState = PresentationState()
     @State private var threadAutorefresher = ThreadAutoRefresher()
     @State var viewModel: ThreadViewModel
@@ -31,6 +33,12 @@ struct ThreadView: View {
     @State private var showAutoRefreshToast: Bool = false
     @State private var autoRefreshToastMessage: String = ""
     @State private var isSearching: Bool = false
+
+    // Gallery hero animation state
+    @State private var galleryDragOffset: CGFloat = 0
+    @State private var galleryBackgroundOpacity: Double = 1
+    @State private var isGalleryZoomed: Bool = false
+    @State private var isGallerySeeking: Bool = false
 
     @State private var scene: SKScene = {
         let s = SnowScene()
@@ -101,6 +109,13 @@ struct ThreadView: View {
                                 }
                             }
                         }
+                        .scrollDisabled(presentationState.presentingGallery && !presentationState.presentingReplies)
+                    }
+
+                    // Gallery hero overlay
+                    if presentationState.presentingGallery && !presentationState.presentingReplies {
+                        galleryOverlayContent
+                            .zIndex(10)
                     }
                 }
                 .overlay(alignment: .bottom) {
@@ -117,11 +132,12 @@ struct ThreadView: View {
                     }
                 }
                 .sheet(
-                    isPresented: $presentationState.presentingGallery,
+                    isPresented: Binding(
+                        get: { presentationState.presentingGallery && presentationState.presentingReplies },
+                        set: { if !$0 { presentationState.presentingGallery = false } }
+                    ),
                     onDismiss: {
-                        // reneable this if it got disabled
                         UIApplication.shared.isIdleTimerDisabled = false
-
                     },
                     content: {
                         gallerySheetContent
@@ -173,7 +189,10 @@ struct ThreadView: View {
                     }
                 }
                 .environment(presentationState)
+                .environment(\.galleryNamespace, galleryNamespace)
                 .navigationTitle(viewModel.title)
+                .toolbar(presentationState.presentingGallery && !presentationState.presentingReplies ? .hidden : .automatic, for: .navigationBar)
+                .statusBar(hidden: presentationState.presentingGallery && !presentationState.presentingReplies)
                 .searchable(text: $viewModel.searchText, isPresented: $isSearching)
                 .onChange(of: viewModel.searchText) { _, _ in
                     viewModel.updateSearchResults()
@@ -398,6 +417,80 @@ struct ThreadView: View {
 }
 
 extension ThreadView {
+    // MARK: - Gallery Hero Overlay
+
+    @ViewBuilder
+    private var galleryOverlayContent: some View {
+        ZStack {
+            Color.black
+                .ignoresSafeArea()
+                .opacity(galleryBackgroundOpacity)
+
+            GalleryView(index: presentationState.galleryIndex)
+                .onMediaChanged { zoomed in
+                    isGalleryZoomed = zoomed
+                }
+                .onSeekChanged { seeking in
+                    isGallerySeeking = seeking
+                }
+                .onDismissDrag { translation in
+                    galleryDragOffset = translation
+                    let progress = min(translation / 300, 1)
+                    galleryBackgroundOpacity = 1 - (progress * 0.6)
+                }
+                .onDismissDragEnded { velocity in
+                    // Rubber-banded offset is small (~30-50pt for big drags), so use low threshold
+                    // velocity.y < 0 means user was dragging content offset downward (finger moving down)
+                    let offsetThreshold: CGFloat = 20
+                    let velocityThreshold: CGFloat = 0.3
+                    if galleryDragOffset > offsetThreshold || velocity < -velocityThreshold {
+                        dismissGallery()
+                    } else {
+                        withAnimation(.spring(response: 0.3, dampingFraction: 0.8)) {
+                            galleryDragOffset = 0
+                            galleryBackgroundOpacity = 1
+                        }
+                    }
+                }
+                .onClosePressed {
+                    dismissGallery()
+                }
+                .environment(appState)
+                .environment(presentationState)
+                .environment(viewModel)
+                .matchedGeometryEffect(
+                    id: "gallery-\(presentationState.galleryIndex)",
+                    in: galleryNamespace,
+                    isSource: true
+                )
+                .offset(y: galleryDragOffset)
+                .scaleEffect(galleryDragScale)
+                .onAppear {
+                    threadAutorefresher.cancelTimer()
+                }
+                .onDisappear {
+                    threadAutorefresher.startTimer()
+                }
+        }
+        .transition(.opacity)
+    }
+
+    private var galleryDragScale: CGFloat {
+        let progress = min(abs(galleryDragOffset) / 300, 1)
+        return 1 - (progress * 0.3)
+    }
+
+    private func dismissGallery() {
+        withAnimation(.spring(response: 0.35, dampingFraction: 0.85)) {
+            presentationState.presentingGallery = false
+            galleryDragOffset = 0
+            galleryBackgroundOpacity = 1
+        }
+        UIApplication.shared.isIdleTimerDisabled = false
+    }
+
+    // MARK: - Gallery Sheet (fallback for replies context)
+
     @ViewBuilder
     private var gallerySheetContent: some View {
         let gallery = GalleryView(

--- a/swiftchan/Views/Media/Gallery/GalleryView.swift
+++ b/swiftchan/Views/Media/Gallery/GalleryView.swift
@@ -6,7 +6,6 @@
 //
 
 import SwiftUI
-import SwiftUIIntrospect
 import UIKit
 
 struct GalleryView: View {
@@ -26,10 +25,13 @@ struct GalleryView: View {
     @State private var isSeeking = false
     @State private var isZoomed = false
     @State private var pagerScrollView: UIScrollView?
-    @State private var sheetPresentationController: UISheetPresentationController?
 
     var onMediaChanged: ((Bool) -> Void)?
     var onPageDragChanged: ((CGFloat) -> Void)?
+    var onSeekChanged: ((Bool) -> Void)?
+    var onDismissDrag: ((CGFloat) -> Void)?
+    var onDismissDragEnded: ((CGFloat) -> Void)?
+    var onClosePressed: (() -> Void)?
 
     init(index: Int) {
         self.index = index
@@ -54,6 +56,16 @@ struct GalleryView: View {
                 },
                 onDragEnded: {
                     handlePagerDragEnded()
+                },
+                onDismissDrag: { translation in
+                    if !isZoomed && !isSeeking {
+                        onDismissDrag?(translation)
+                    }
+                },
+                onDismissDragEnded: { velocity in
+                    if !isZoomed && !isSeeking {
+                        onDismissDragEnded?(velocity)
+                    }
                 },
                 onScrollViewCaptured: { scrollView in
                     guard pagerScrollView !== scrollView else { return }
@@ -105,24 +117,27 @@ struct GalleryView: View {
                         .padding(.bottom, 60)
                 }
             }
+
+            // Close button
+            VStack {
+                HStack {
+                    Spacer()
+                    Button(action: { onClosePressed?() }) {
+                        Image(systemName: "xmark.circle.fill")
+                            .font(.system(size: 28))
+                            .symbolRenderingMode(.hierarchical)
+                            .foregroundStyle(.white)
+                            .shadow(radius: 4)
+                    }
+                    .padding(16)
+                }
+                Spacer()
+            }
         }
         .onDisappear {
             restorePagerScrolling()
-            sheetPresentationController?.presentedViewController.isModalInPresentation = false
         }
         .gesture(canShowPreview && showGalleryPreview ? showPreviewTap() : nil)
-        .introspect(.sheet, on: .iOS(.v17, .v18, .v26)) { controller in
-            controller.prefersGrabberVisible = true
-            controller.prefersScrollingExpandsWhenScrolledToEdge = false
-            controller.detents = [.large()]
-            // Defer state update to avoid "Modifying state during view update" warning
-            if sheetPresentationController !== controller {
-                DispatchQueue.main.async {
-                    sheetPresentationController = controller
-                }
-            }
-            updateInteractiveDismiss(using: controller)
-        }
         .statusBar(hidden: true)
     }
 
@@ -139,7 +154,6 @@ struct GalleryView: View {
                     if zoomed {
                         showPreview = false
                     }
-                    updateInteractiveDismiss()
                     onMediaChanged?(zoomed)
                 }
                 .onSeekChanged { seeking in
@@ -147,7 +161,7 @@ struct GalleryView: View {
                     refreshPagingState()
                     canShowPreview = !seeking
                     canShowContextMenu = !seeking
-                    updateInteractiveDismiss()
+                    onSeekChanged?(seeking)
                 }
                 .mediaDownloadMenu(url: media.url, canShowContextMenu: $canShowContextMenu)
                 .accessibilityIdentifier(
@@ -183,7 +197,6 @@ struct GalleryView: View {
         var currentItem = viewModel.media[index]
         currentItem.isSelected = true
         viewModel.media[index] = currentItem
-        updateInteractiveDismiss()
 
         // Dynamic prefetching: update prefetch window as user swipes
         viewModel.prefetch(currentIndex: index)
@@ -219,15 +232,6 @@ struct GalleryView: View {
         }
         refreshPagingState()
     }
-
-    private func updateInteractiveDismiss(using controller: UISheetPresentationController? = nil) {
-        let controller = controller ?? sheetPresentationController
-        guard let controller else { return }
-        let allowDismiss = !isZoomed && !isSeeking
-        DispatchQueue.main.async {
-            controller.presentedViewController.isModalInPresentation = !allowDismiss
-        }
-    }
 }
 
 extension GalleryView: Buildable {
@@ -236,6 +240,18 @@ extension GalleryView: Buildable {
     }
     func onPageDragChanged(_ callback: ((CGFloat) -> Void)?) -> Self {
         mutating(keyPath: \.onPageDragChanged, value: callback)
+    }
+    func onSeekChanged(_ callback: ((Bool) -> Void)?) -> Self {
+        mutating(keyPath: \.onSeekChanged, value: callback)
+    }
+    func onDismissDrag(_ callback: ((CGFloat) -> Void)?) -> Self {
+        mutating(keyPath: \.onDismissDrag, value: callback)
+    }
+    func onDismissDragEnded(_ callback: ((CGFloat) -> Void)?) -> Self {
+        mutating(keyPath: \.onDismissDragEnded, value: callback)
+    }
+    func onClosePressed(_ callback: (() -> Void)?) -> Self {
+        mutating(keyPath: \.onClosePressed, value: callback)
     }
 }
 

--- a/swiftchan/Views/Media/Gallery/VerticalPagerView.swift
+++ b/swiftchan/Views/Media/Gallery/VerticalPagerView.swift
@@ -15,6 +15,8 @@ struct VerticalPagerView<Content: View>: UIViewControllerRepresentable {
     var onPageChanged: ((Int) -> Void)?
     var onDragChanged: ((CGFloat) -> Void)?
     var onDragEnded: (() -> Void)?
+    var onDismissDrag: ((CGFloat) -> Void)?
+    var onDismissDragEnded: ((CGFloat) -> Void)?
     var onScrollViewCaptured: ((UIScrollView) -> Void)?
     var content: (Int) -> Content
 
@@ -66,6 +68,8 @@ extension VerticalPagerView {
         weak var scrollView: UIScrollView?
         var currentIndex: Int = 0
         var isSettingViewController = false
+        private var isDismissTracking = false
+        private var dismissVelocity: CGFloat = 0
 
         init(parent: VerticalPagerView) {
             self.parent = parent
@@ -156,12 +160,40 @@ extension VerticalPagerView {
         func scrollViewDidScroll(_ scrollView: UIScrollView) {
             guard parent.canScroll else { return }
             let baseline = scrollView.bounds.height
-            let translation = baseline - scrollView.contentOffset.y
+            let rawOffset = scrollView.contentOffset.y
+
+            // Dismiss tracking: page 0, user dragging down past boundary
+            if currentIndex == 0 && rawOffset < baseline && !isSettingViewController {
+                if !isDismissTracking {
+                    isDismissTracking = true
+                }
+                let dismissTranslation = baseline - rawOffset
+                parent.onDismissDrag?(dismissTranslation)
+                return
+            }
+
+            // Only reset dismiss if user is actively dragging back up (not deceleration)
+            if isDismissTracking && rawOffset >= baseline && scrollView.isDragging {
+                isDismissTracking = false
+                parent.onDismissDrag?(0)
+            }
+
+            let translation = baseline - rawOffset
             parent.onDragChanged?(translation)
         }
 
         func scrollViewWillEndDragging(_ scrollView: UIScrollView, withVelocity velocity: CGPoint, targetContentOffset: UnsafeMutablePointer<CGPoint>) {
             guard parent.canScroll else { return }
+
+            if isDismissTracking {
+                isDismissTracking = false
+                // Force scroll back to rest position
+                targetContentOffset.pointee.y = scrollView.bounds.height
+                // Fire dismiss end with velocity immediately (before deceleration resets state)
+                parent.onDismissDragEnded?(velocity.y)
+                return
+            }
+
             parent.onDragChanged?(0)
         }
 

--- a/swiftchanUITests/swiftchanUITests.swift
+++ b/swiftchanUITests/swiftchanUITests.swift
@@ -6,7 +6,6 @@
 //
 
 import XCTest
-@testable import swiftchan
 
 class SwiftchanUITests: XCTestCase {
     var app: XCUIApplication!
@@ -81,5 +80,51 @@ class SwiftchanUITests: XCTestCase {
         app.longPressGalleryMedia(0)
         app.tapCopyToPasteboardButton()
         XCTAssert(UIPasteboard.general.hasURLs)
+    }
+
+    @MainActor func testGalleryExpandAnimation() throws {
+        // Navigate to a board and open a thread
+        app.goToBoard("a")
+        app.goToOPThread(0)
+        app.assertPost(0)
+
+        // Screenshot 1: Thread view with thumbnail visible
+        let thumbnailBeforeTap = app.thumbnailMediaImage(0)
+        assertExistence(thumbnailBeforeTap)
+        let threadScreenshot = XCTAttachment(screenshot: app.screenshot())
+        threadScreenshot.name = "1_thread_with_thumbnail"
+        threadScreenshot.lifetime = .keepAlways
+        add(threadScreenshot)
+
+        // Tap the thumbnail to trigger the gallery hero animation
+        app.tapThumbnailMedia(0)
+
+        // Screenshot 2: Gallery overlay should be visible
+        let galleryMedia = app.galleryMediaImage(0)
+        let galleryAppeared = galleryMedia.waitForExistence(timeout: 10)
+        let galleryScreenshot = XCTAttachment(screenshot: app.screenshot())
+        galleryScreenshot.name = "2_gallery_expanded"
+        galleryScreenshot.lifetime = .keepAlways
+        add(galleryScreenshot)
+
+        XCTAssert(galleryAppeared, "Gallery media should appear after tapping thumbnail")
+
+        // Swipe down on first page to trigger interactive dismiss
+        galleryMedia.swipeDown(velocity: .slow)
+        Thread.sleep(forTimeInterval: 0.5)
+
+        // Screenshot 3: After dismiss - should be back to thread view
+        let dismissScreenshot = XCTAttachment(screenshot: app.screenshot())
+        dismissScreenshot.name = "3_after_dismiss"
+        dismissScreenshot.lifetime = .keepAlways
+        add(dismissScreenshot)
+
+        // Verify thumbnail is visible again (gallery dismissed)
+        let thumbnailAfterDismiss = app.thumbnailMediaImage(0)
+        assertExistence(thumbnailAfterDismiss)
+    }
+
+    private func assertExistence(_ element: XCUIElement, timeout: TimeInterval = 10) {
+        XCTAssert(element.waitForExistence(timeout: timeout), "Element not found: \(element.debugDescription)")
     }
 }


### PR DESCRIPTION
## Summary
- Replace `.sheet` gallery presentation with ZStack overlay + `matchedGeometryEffect` for hero animation from thumbnail to fullscreen
- Add interactive drag-to-dismiss on first page via UIScrollView boundary bounce detection in VerticalPagerView
- Add close button (X) for dismissing from any page
- Keep `.sheet` fallback when gallery is opened from RepliesView context
- Add UI test with screenshots for expand + dismiss flow

## Known Issues
- Interactive drag-to-dismiss is janky — UIScrollView rubber-banding limits the offset range, making the visual feedback feel stiff
- Animation timing between matchedGeometryEffect and the pager content could be smoother
- Needs manual testing and polish

## Test plan
- [ ] Tap thumbnail → gallery expands with spring animation
- [ ] Drag down on first media → gallery moves with finger, dismisses on threshold
- [ ] Swipe to page 2+ → close button (X) dismisses gallery
- [ ] Swipe back to page 0 → drag-to-dismiss works again
- [ ] Zoom into image → drag-to-dismiss disabled
- [ ] Open gallery from replies → falls back to sheet presentation

Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)